### PR TITLE
Update sample to DVM SDK 3.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This README describes how you can integrate with the Flipp Platform SDK.
 - [About the SDK](#about)
 - [Quick Start](#quick-start)
 - [How to Integrate the SDK](#how-to)
+- [Rendering Options & Advanced Features](#features)
 - [Delegate Methods](#delegate-methods)
 
 ## About the SDK <a name="about"></a>
@@ -18,6 +19,12 @@ form (DVM).
 The DVM format renders publications in a dynamic way that maintains
 responsiveness and merchandising flexibility, while also providing a host of
 features to allow users to interact with offers.
+
+> [!NOTE]
+>
+> The SDK exposes self-contained value types (`Publication`, `Offer`,
+> `Promotion`, `OfferPricing`, `RenderingType`, `StrategyResult`). You do not
+> need any additional packages to build against it.
 
 ## Quick Start <a name="quick-start"></a>
 
@@ -42,51 +49,44 @@ features to allow users to interact with offers.
 
 1. Add the DVM SDK as a dependency through SPM (Swift Package Manager).
 
-- Navigate to Package Dependecies > Click '+' to add a package.
+- Navigate to Package Dependencies > Click '+' to add a package.
 - Enter the SDK repository's URL `https://github.com/wishabi/dvm-ios-binaries/`
   as the package URL.
 - Select the package when prompted.
 
-3. Initialize the SDK early in your application life cycle by providing a
+2. Initialize the SDK early in your application life cycle by providing a
    `clientToken` key, and an optional `userId`.
-
-```swift
-  /// SDK initialization function, provides information necessary to the SDK.
-  /// Needs to be called before any other function.
-  /// - Parameters:
-  ///   - clientToken: Identification token for the client.
-  ///   - userId: Value that uniquely identifies the user.
-  public static func initialize(clientToken: String, userId: String?)
-```
-
-Example:
 
 ```swift
 import dvm_sdk
 
-DVMSDK.initialize(clientToken: "experimental-key-that-is-super-secret-and-secure-prd", userId: nil)
+DVMSDK.initialize(clientToken: "your-flipp-provided-key", userId: nil)
 ```
 
 3. Fetch a list of publications by calling
-   `DVMSDK.fetchPublicationsList(merchantId:storeCode:language:completion:)`:
+   `DVMSDK.fetchPublicationsList(...)`. It is `async` and returns an array of
+   `Publication` values:
 
 ```swift
-/// Retrieves a list of publications and invokes the completion handler with the results.
-///
-/// If an error occurs during the process the error of the completion will be non nil and the publication list will be empty.
-///
 /// - Parameters:
 ///   - merchantId: Merchant identifier to retrieve the publications for.
 ///   - storeCode: Store identifier for the publications.
-///   - language: The 2 characters ISO language code used to render the publication.
+///   - language: The 2 character ISO language code.
 ///   - resultsCount: number of results per page, defaults to 10.
 ///   - pageToken: token for pagination, needed to fetch subsequent results.
-///   - completion: closure that will be called with results.
-///
-/// New in SDK 1.1.0 update: entity `Publication` now contains `renderingTypes` member, an array of `RenderingType` which indicates the available rendering modes for the publication.
-
-public static func fetchPublicationsList(merchantId: String, storeCode: String, language: String, resultsCount: Int = 10, pageToken: String? = nil, completion: @escaping PublicationsListCompletion) throws
+/// - Returns: A list of `Publication`.
+public static func fetchPublicationsList(
+  merchantId: String,
+  storeCode: String,
+  language: String?,
+  resultsCount: Int = 10,
+  pageToken: String? = nil
+) async throws -> [Publication]
 ```
+
+A `Publication` exposes `id`, `merchantId`, `name`, `description`, `imageURL`,
+`validFrom`, `validTo`, `language`, `tags`, and `renderingTypes` (`[RenderingType]`,
+`.dvm` / `.sfml`) so you can tell which engines a publication supports.
 
 Example from `PublicationsViewController.swift`:
 
@@ -96,72 +96,69 @@ let publications = try await DVMSDK.fetchPublicationsList(
   storeCode: storeCode,
   language: Locale.preferredLanguageCode() ?? "en")
 await MainActor.run { [weak self] in
-  self?.tableView.refreshControl?.endRefreshing()
   self?.publications = publications
   self?.tableView.reloadData()
+}
 ```
 
 4. Once a publication is selected, create an instance of `DVMRendererView` to
    render the publication and set its delegate appropriately:
 
 ```swift
-/// Creates and returns a rendering view for the publication with the corresponding id, respecting the requested rendering mode.
-/// .No references are kept within the SDK of this view, it is the responsibility of the caller to prevent deallocation.
-/// A delegate needs to be assigned to the view in order to receive callbacks from its while rendering.
 /// - Parameters:
 ///   - publicationId: Publication id to render.
-///   - merchantId: Merchant id for the publication.
-///   - storeCode: Store code for the publication.
-///   - renderMode: Store identifier for the publications.
-///   - language: The 2 characters ISO language code used to render the publication.
+///   - publicationInfo: Location or merchant info for the publication.
+///   - renderMode: The rendering mode to use (`.dvm` or `.sfml`).
+///   - language: The 2 character ISO language code used to render the publication.
 ///   - shouldPersistWebsiteDataToDisk: Whether website data should persist to disk (default is false).
-/// - Throws: DVMSDKError.sdkNotIntialized in case this function is called before initializing the SDK
-/// - Returns: A DVM renderer view.
+///   - disableZoom: Whether pinch-to-zoom should be disabled (default is false).
+///   - linkedOfferId: The id of an offer to guarantee is linked into the publication when rendered, nil if none.
 public static func createRenderingView(
-   publicationId: String,
-   merchantId: String,
-   storeCode: String,
-   renderMode: RenderMode,
-   language: String?,
-   shouldPersistWebsiteDataToDisk: Bool = false
+  publicationId: String,
+  publicationInfo: PublicationInfo,
+  renderMode: RenderMode,
+  language: String?,
+  shouldPersistWebsiteDataToDisk: Bool = false,
+  disableZoom: Bool = false,
+  linkedOfferId: String? = nil
 ) throws -> DVMRendererView
 ```
 
-Example for using `createRenderingView` within
-`PublicationViewController.swift`:
+`PublicationInfo` selects how the publication is located:
 
 ```swift
-    if let rendererView = try? DVMSDK.createRenderingView(
-      publicationId: publicationID,
-      merchantId: merchantId,
-      storeCode: storeCode,
-      renderMode: renderingMode,
-      language: Locale.preferredLanguageCode() ?? "en"
-    ) {
-      rendererView.rendererDelegate = self
-      rendererView.translatesAutoresizingMaskIntoConstraints = false
-      view.addSubview(rendererView)
-      self.rendererView = rendererView
-      setupConstraints()
-      spinner.stopAnimating()
-    }
+public enum PublicationInfo {
+  case byLocation(postalCode: String, countryCode: String)
+  case byMerchant(merchantId: String, storeCode: String)
+}
 ```
 
-5. When the user taps on an item, the following event is called with the item
-   details as the parameter:
+Example from `PublicationViewController.swift`:
 
 ```swift
-/// Called when an offer item is tapped.
-///
-/// - Parameter result: The result which contains an `Offer` on success or a
-/// `DVMSDKError` on failure.
-func didTap(result: Result<dvm_sdk.Offer, dvm_sdk.DVMSDKError>)
+let publicationInfo: PublicationInfo = .byMerchant(merchantId: merchantId, storeCode: storeCode)
+
+if let rendererView = try? DVMSDK.createRenderingView(
+  publicationId: publicationID,
+  publicationInfo: publicationInfo,
+  renderMode: renderingMode,
+  language: Locale.preferredLanguageCode() ?? "en",
+  shouldPersistWebsiteDataToDisk: false,
+  disableZoom: renderOptions.disableZoom,
+  linkedOfferId: renderOptions.linkedOfferId
+) {
+  rendererView.rendererDelegate = self
+  rendererView.translatesAutoresizingMaskIntoConstraints = false
+  view.addSubview(rendererView)
+  self.rendererView = rendererView
+}
 ```
 
-Example from `PublicationsViewController.swift`:
+5. When the user taps an item, the delegate is called with the offer details.
+   Offers are delivered as the SDK's `Offer` value type:
 
 ```swift
-func didTap(result: Result<dvm_sdk.Offer, dvm_sdk.DVMSDKError>) {
+func didTap(result: Result<Offer, DVMSDKError>) {
   switch result {
   case .success(let offer):
     self.pushDetailsController(for: offer)
@@ -171,28 +168,102 @@ func didTap(result: Result<dvm_sdk.Offer, dvm_sdk.DVMSDKError>) {
 }
 ```
 
+An `Offer` exposes `id`, `merchantId`, `name`, `description`, `imageURLs`,
+`pricing` (`OfferPricing`), `saleStory`, `disclaimer`, `prePriceText`,
+`postPriceText`, `validFrom`, and `validTo`.
+
+## Rendering Options & Advanced Features <a name="features"></a>
+
+The sample app's initial screen exposes a "Rendering options" section that
+demonstrates the newer capabilities. All of these are shown end-to-end in
+`InitialViewController.swift` and `PublicationViewController.swift`.
+
+- **Location-based rendering** — provide a postal code + country code and the
+  renderer is created with `PublicationInfo.byLocation(postalCode:countryCode:)`
+  instead of `.byMerchant(...)`.
+- **Disable zoom** — pass `disableZoom: true` to `createRenderingView` to turn
+  off pinch-to-zoom.
+- **Linked offer** — pass `linkedOfferId:` to guarantee a specific offer is
+  linked into the publication when it renders. Pair it with
+  `didReceiveStrategyResults(_:)` to detect when linking failed:
+
+  ```swift
+  func didReceiveStrategyResults(_ results: [StrategyResult]) {
+    if let failure = results.first(where: { $0.errorMessage != nil }) {
+      // surface failure.errorMessage — e.g. the linked offer could not be loaded
+    }
+  }
+  ```
+
+- **Native content overlay** — `DVMRendererView` exposes `bottomContentInset`
+  and `scrollView`. Set `bottomContentInset` to reserve scroll space so your own
+  native views (e.g. a footer/banner) can overlay the rendered publication
+  without covering content.
+- **Promotions** — handle `didTapPromotion(result:)`,
+  `publicationScrollToPromotionResponse(_:)`, and
+  `publicationPromotionImpression(ids:)`. Promotions are delivered as the
+  `Promotion` value type.
+- **Through-the-merchant (TTM) links** — handle `didTapTTM(url:)` to open the
+  destination URL.
+- **Scroll telemetry** — `publicationDidScroll(contentOffset:contentSize:viewportHeight:)`,
+  `publicationDidEndDragging(willDecelerate:)`, and
+  `publicationDidEndDecelerating()`.
+
 ## Delegate Methods <a name="delegate-methods"></a>
 
-The Flipp Platform SDK can send events notifying your app about actions that the
-user has taken. The following events are supported:
+The Flipp Platform SDK can send events notifying your app about actions the user
+has taken. Most methods have default (empty) implementations, so you only
+implement the ones you need.
 
 ```swift
-/// The DVMRendererDelegate protocol defines a set of methods to handle interactions and state changes related to the rendering of offers.
-/// This protocol is intended to be adopted by a delegate object to handle tap events, successful loading, and failure scenarios from an offer rendering view.
-public protocol DVMRendererDelegate : AnyObject {
+public protocol DVMRendererDelegate: AnyObject {
+  /// Called when an offer item is tapped.
+  func didTap(result: Result<Offer, DVMSDKError>)
 
-    /// Called when an offer item is tapped.
-    ///
-    /// - Parameter result: The result which contains an `Offer` on success or a
-    /// `DVMSDKError` on failure.
-    func didTap(result: Result<dvm_sdk.Offer, dvm_sdk.DVMSDKError>)
+  /// Called when a long tap is detected.
+  func didLongTap(result: Result<Offer?, DVMSDKError>)
 
-    /// Called when the offer rendering has finished loading successfully.
-    func didFinishLoad()
+  /// Called when the offer rendering has finished loading successfully.
+  func didFinishLoad(legacyMap: [String: String])
 
-    /// Called when the offer rendering failed to load.
-    ///
-    /// - Parameter error: The error that occurred during the loading process.
-    func didFailToLoad(error: any Error)
+  /// Called when the offer rendering failed to load.
+  func didFailToLoad(error: Error)
+
+  /// Called when the publication has finished scrolling due to a scroll-to request.
+  func publicationScrollToResponse(_ offer: Offer)
+
+  /// Called when the publication has finished scrolling due to user interaction.
+  func publicationScrollTo(flyerHeight: Int, viewportBottomOffset: Int)
+
+  /// Called when an impression logic hits on the DVM publication.
+  func publicationImpression(ids: [String])
+
+  /// Called when a promotion impression event is received.
+  func publicationPromotionImpression(ids: [String])
+
+  /// Called when a TTM (through-the-merchant) link is tapped.
+  func didTapTTM(url: URL)
+
+  /// Called when a promotion item is tapped.
+  func didTapPromotion(result: Result<Promotion, DVMSDKError>)
+
+  /// Called when the publication has finished scrolling to a promotion.
+  func publicationScrollToPromotionResponse(_ promotion: Promotion)
+
+  /// Called when logic for an engaged visit triggers.
+  func publicationTriggeredEngagedVisit()
+
+  /// Called when the publication scrolls.
+  func publicationDidScroll(contentOffset: CGPoint, contentSize: CGSize, viewportHeight: CGFloat)
+
+  /// Called when the scroll view finishes dragging.
+  func publicationDidEndDragging(willDecelerate: Bool)
+
+  /// Called when the scroll view finishes decelerating.
+  func publicationDidEndDecelerating()
+
+  /// Called when the publication's hydration returns post-processing strategy results
+  /// (e.g. the offer-linking strategy used when a `linkedOfferId` is provided).
+  func didReceiveStrategyResults(_ results: [StrategyResult])
 }
 ```

--- a/dvm-sample.xcodeproj/project.pbxproj
+++ b/dvm-sample.xcodeproj/project.pbxproj
@@ -484,7 +484,7 @@
 			repositoryURL = "https://github.com/wishabi/dvm-ios-binaries/";
 			requirement = {
 				kind = exactVersion;
-				version = 2.1.6;
+				version = 3.5.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/dvm-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/dvm-sample.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -6,8 +6,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wishabi/dvm-ios-binaries/",
       "state" : {
-        "revision" : "5479ccbdcb4d5df1beeb7eb920c75c098e4607f0",
-        "version" : "2.1.6"
+        "revision" : "5163068db7498bbf178bd6643f7c979cb0eddcde",
+        "version" : "3.5.1"
       }
     }
   ],

--- a/dvm-sample/InitialViewController.swift
+++ b/dvm-sample/InitialViewController.swift
@@ -2,101 +2,115 @@
 
 import UIKit
 
+/// Options collected on the initial screen that are forwarded to the renderer to
+/// showcase the SDK's rendering configuration (location vs merchant, zoom, linked offer).
+struct RenderOptions {
+  var disableZoom: Bool
+  var linkedOfferId: String?
+  var postalCode: String?
+  var countryCode: String?
+}
+
 class InitialViewController: UIViewController, UITextFieldDelegate {
 
-    let merchantLabel: UILabel = {
-      let label = UILabel()
-      label.text = "Merchant"
-      label.textColor = .default5
-      label.translatesAutoresizingMaskIntoConstraints = false
-      return label
-    }()
+  private let merchantTextField = InitialViewController.makeField(placeholder: "Enter merchant", text: "2018")
+  private let storeCodeTextField = InitialViewController.makeField(placeholder: "Enter store code", text: "1174")
+  private let postalCodeTextField = InitialViewController.makeField(placeholder: "Optional, e.g. M5V 2H1")
+  private let countryCodeTextField = InitialViewController.makeField(placeholder: "Optional, e.g. CA")
+  private let linkedOfferTextField = InitialViewController.makeField(placeholder: "Optional offer id to link")
+  private let disableZoomSwitch = UISwitch()
 
-    let merchantTextField: UITextField = {
-      let textField = BorderedTextField()
-      textField.placeholder = "Enter merchant"
-      textField.text = "2018"
-      textField.translatesAutoresizingMaskIntoConstraints = false
-      return textField
-    }()
+  private let loadPublicationsButton: UIButton = {
+    let button = UIButton(frame: .zero)
+    button.titleLabel?.font = UIFont.boldSystemFont(ofSize: .medium)
+    button.setTitleColor(.default0, for: .normal)
+    button.tintColor = .default0
+    button.setTitle("Load Publications", for: .normal)
+    button.translatesAutoresizingMaskIntoConstraints = false
+    button.backgroundColor = .primary3
+    button.layer.cornerRadius = .extraExtraSmall
+    button.contentEdgeInsets = UIEdgeInsets(top: 8, left: 12, bottom: 8, right: 12)
+    return button
+  }()
 
-    let storeCodeLabel: UILabel = {
-      let label = UILabel()
-      label.text = "Store Code"
-      label.textColor = .default5
-      label.translatesAutoresizingMaskIntoConstraints = false
-      return label
-    }()
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    view.backgroundColor = .appBackground
 
-    let storeCodeTextField: UITextField = {
-      let textField = BorderedTextField()
-      textField.placeholder = "Enter store code"
-      textField.text = "1174"
-      textField.translatesAutoresizingMaskIntoConstraints = false
-      return textField
-    }()
+    let stack = UIStackView(arrangedSubviews: [
+      labeledRow("Merchant", merchantTextField),
+      labeledRow("Store Code", storeCodeTextField),
+      sectionLabel("Rendering options"),
+      labeledRow("Postal Code (location render)", postalCodeTextField),
+      labeledRow("Country Code (location render)", countryCodeTextField),
+      labeledRow("Linked Offer ID", linkedOfferTextField),
+      switchRow("Disable Zoom", disableZoomSwitch),
+      loadPublicationsButton,
+    ])
+    stack.axis = .vertical
+    stack.spacing = 16
+    stack.alignment = .fill
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(stack)
 
-    let loadPublicationsButton: UIButton = {
-      let button = UIButton(frame: .zero)
-      button.titleLabel?.font = UIFont.boldSystemFont(ofSize: .medium)
-      button.setTitleColor(.default0, for: .normal)
-      button.tintColor = .default0
-      button.setTitle("Load Publications", for: .normal)
-      button.translatesAutoresizingMaskIntoConstraints = false
-      button.backgroundColor = .primary3
-      button.layer.cornerRadius = .extraExtraSmall
-      button.contentEdgeInsets = UIEdgeInsets(
-        top: 8,
-        left: 12,
-        bottom: 8,
-        right: button.contentEdgeInsets.right + 12)
-      return button
-    }()
+    NSLayoutConstraint.activate([
+      stack.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
+      stack.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+      stack.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+    ])
 
-    override func viewDidLoad() {
-      super.viewDidLoad()
-      view.backgroundColor = .appBackground
+    [merchantTextField, storeCodeTextField, postalCodeTextField,
+     countryCodeTextField, linkedOfferTextField].forEach { $0.delegate = self }
 
-      setupViews()
-      setupConstraints()
+    let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
+    view.addGestureRecognizer(tapGesture)
+    loadPublicationsButton.addTarget(self, action: #selector(loadPublicationsButtonTapped), for: .touchUpInside)
+  }
 
-      // Add tap gesture to dismiss keyboard
-      let tapGesture = UITapGestureRecognizer(target: self, action: #selector(dismissKeyboard))
-      view.addGestureRecognizer(tapGesture)
-      loadPublicationsButton.addTarget(self, action: #selector(loadPublicationsButtonTapped), for: .touchUpInside)
-    }
+  // MARK: - View builders
 
-    func setupViews() {
-      view.addSubview(merchantLabel)
-      view.addSubview(merchantTextField)
-      view.addSubview(storeCodeLabel)
-      view.addSubview(storeCodeTextField)
-      view.addSubview(loadPublicationsButton)
+  private static func makeField(placeholder: String, text: String? = nil) -> UITextField {
+    let textField = BorderedTextField()
+    textField.placeholder = placeholder
+    textField.text = text
+    textField.autocapitalizationType = .none
+    textField.autocorrectionType = .no
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    return textField
+  }
 
-      merchantTextField.delegate = self
-      storeCodeTextField.delegate = self
-    }
+  private func sectionLabel(_ text: String) -> UILabel {
+    let label = UILabel()
+    label.text = text
+    label.textColor = .default5
+    label.font = UIFont.boldSystemFont(ofSize: .medium)
+    return label
+  }
 
-    func setupConstraints() {
-      NSLayoutConstraint.activate([
-        merchantLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 20),
-        merchantLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+  private func labeledRow(_ title: String, _ field: UITextField) -> UIStackView {
+    let label = UILabel()
+    label.text = title
+    label.textColor = .default5
+    let row = UIStackView(arrangedSubviews: [label, field])
+    row.axis = .vertical
+    row.spacing = 8
+    return row
+  }
 
-        merchantTextField.topAnchor.constraint(equalTo: merchantLabel.bottomAnchor, constant: 8),
-        merchantTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        merchantTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+  private func switchRow(_ title: String, _ control: UISwitch) -> UIStackView {
+    let label = UILabel()
+    label.text = title
+    label.textColor = .default5
+    let spacer = UIView()
+    spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    let row = UIStackView(arrangedSubviews: [label, spacer, control])
+    row.axis = .horizontal
+    row.spacing = 8
+    row.alignment = .center
+    return row
+  }
 
-        storeCodeLabel.topAnchor.constraint(equalTo: merchantTextField.bottomAnchor, constant: 20),
-        storeCodeLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-
-        storeCodeTextField.topAnchor.constraint(equalTo: storeCodeLabel.bottomAnchor, constant: 8),
-        storeCodeTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        storeCodeTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-
-        loadPublicationsButton.topAnchor.constraint(equalTo: storeCodeTextField.bottomAnchor, constant: 20),
-        loadPublicationsButton.centerXAnchor.constraint(equalTo: view.centerXAnchor)
-      ])
-    }
+  // MARK: - Actions
 
   @objc func dismissKeyboard() {
     view.endEditing(true)
@@ -107,10 +121,16 @@ class InitialViewController: UIViewController, UITextFieldDelegate {
     return true
   }
 
+  private func nonEmpty(_ textField: UITextField) -> String? {
+    guard let text = textField.text?.trimmingCharacters(in: .whitespacesAndNewlines),
+          !text.isEmpty else { return nil }
+    return text
+  }
+
   @objc func loadPublicationsButtonTapped() {
-    guard let merchant = merchantTextField.text, !merchant.isEmpty,
-          let storeCode = storeCodeTextField.text, !storeCode.isEmpty else {
-      let alert = UIAlertController(title: "Error", message: "Please fill in all fields", preferredStyle: .alert)
+    guard let merchant = nonEmpty(merchantTextField),
+          let storeCode = nonEmpty(storeCodeTextField) else {
+      let alert = UIAlertController(title: "Error", message: "Please fill in merchant and store code", preferredStyle: .alert)
       alert.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
       present(alert, animated: true, completion: nil)
       return
@@ -119,6 +139,11 @@ class InitialViewController: UIViewController, UITextFieldDelegate {
     let publicationsViewController = PublicationsViewController()
     publicationsViewController.merchantID = merchant
     publicationsViewController.storeCode = storeCode
+    publicationsViewController.renderOptions = RenderOptions(
+      disableZoom: disableZoomSwitch.isOn,
+      linkedOfferId: nonEmpty(linkedOfferTextField),
+      postalCode: nonEmpty(postalCodeTextField),
+      countryCode: nonEmpty(countryCodeTextField))
     navigationController?.navigationBar.barTintColor = .default0
     navigationController?.pushViewController(publicationsViewController, animated: true)
   }

--- a/dvm-sample/Offer Details/OfferDetailsView.swift
+++ b/dvm-sample/Offer Details/OfferDetailsView.swift
@@ -12,110 +12,91 @@ struct OfferDetailsView: View {
   @ObservedObject var viewModel: OfferDetailsViewModel
 
   var body: some View {
-    ScrollView(
-      .vertical,
-      showsIndicators: true) {
-        VStack(
-          alignment: .leading,
-          spacing: 16,
-          content: {
-            if viewModel.imageURLStrings.count > 0 {
-              if viewModel.imageURLStrings.count == 1 {
-                AsyncImage(url: URL(string: viewModel.imageURLStrings.first!)!) { image in
-                  image.image?
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                }
-                .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/, maxHeight: 200, alignment: .center)
-              } else {
-                ScrollView(.horizontal, showsIndicators: true) {
-                  HStack(spacing: 16) {
-                    ForEach(viewModel.imageURLStrings, id: \.self) { imageURLString in
-                      AsyncImage(url: URL(string: imageURLString)!) { image in
-                        image.image?
-                          .resizable()
-                          .aspectRatio(contentMode: .fit)
-                      }
-                      .frame(maxWidth: /*@START_MENU_TOKEN@*/.infinity/*@END_MENU_TOKEN@*/, maxHeight: 200, alignment: .center)
-                    }
-                  }
-                }
+    ScrollView(.vertical, showsIndicators: true) {
+      VStack(alignment: .leading, spacing: 16) {
+        if !viewModel.imageURLStrings.isEmpty {
+          if viewModel.imageURLStrings.count == 1 {
+            offerImage(viewModel.imageURLStrings[0])
+          } else {
+            ScrollView(.horizontal, showsIndicators: true) {
+              HStack(spacing: 16) {
+                ForEach(viewModel.imageURLStrings, id: \.self) { offerImage($0) }
               }
             }
+          }
+        }
 
-            if let name = viewModel.name, !name.isEmpty {
-              Text(name)
-                .bold()
-                .font(.title2)
+        if let name = viewModel.name, !name.isEmpty {
+          Text(name)
+            .bold()
+            .font(.title2)
+        }
+
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Price")
+            .font(.headline)
+          HStack(spacing: 4) {
+            if let prePrice = viewModel.prePriceText, !prePrice.isEmpty {
+              Text(prePrice)
             }
-
-            VStack(alignment: .leading) {
-              Text("V1 Price composition")
-              HStack(spacing: 4) {
-                Text(viewModel.v1Price ?? "")
-                  .bold()
-                  .font(.title2)
-                  .foregroundStyle(.red)
-
-                Text(viewModel.v1PostPrice ?? "")
-              }
-              Text("V1 sale story: \(viewModel.v1SaleStory ?? "")")
+            Text(viewModel.priceText)
+              .bold()
+              .font(.title2)
+              .foregroundStyle(.red)
+            if let postPrice = viewModel.postPriceText, !postPrice.isEmpty {
+              Text(postPrice)
             }
-            VStack(alignment: .leading) {
-              Text("V2 Price composition")
-              HStack(spacing: 4) {
-                Text(viewModel.v2Price ?? "")
-                  .bold()
-                  .font(.title2)
-                  .foregroundStyle(.red)
+          }
+          if let saleStory = viewModel.saleStory, !saleStory.isEmpty {
+            Text(saleStory)
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
+          }
+        }
 
-                Text(viewModel.v2PostPrice ?? "")
-              }
-              Text("V2 sale story: \(viewModel.v2SaleStory ?? "")")
-            }
-            Text(viewModel.validity)
+        Text(viewModel.validity)
 
-            if let description = viewModel.description, !description.isEmpty {
-              VStack(
-                alignment: .leading) {
-                  Text("Description")
-                    .font(.title3)
+        if let description = viewModel.description, !description.isEmpty {
+          VStack(alignment: .leading) {
+            Text("Description")
+              .font(.title3)
+            Text(description)
+          }
+        }
 
-                  Text(description)
-                }
-            }
-
-            if let disclaimer = viewModel.disclaimer {
-              Text(disclaimer)
-            }
-
-            Text(viewModel.sku)
-          })
-        .padding()
+        if let disclaimer = viewModel.disclaimer, !disclaimer.isEmpty {
+          Text(disclaimer)
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
       }
-      .navigationTitle("Offer Details")
+      .padding()
+    }
+    .navigationTitle("Offer Details")
+  }
+
+  private func offerImage(_ urlString: String) -> some View {
+    AsyncImage(url: URL(string: urlString)) { image in
+      image.image?
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+    }
+    .frame(maxWidth: .infinity, maxHeight: 200, alignment: .center)
   }
 }
 
 #Preview {
   OfferDetailsView(
-    viewModel:
-      OfferDetailsViewModel(
-        imageURLStrings: [
-          "https://flipp-image-retrieval.flipp.com/api/aHR0cDovL2Yud2lzaGFiaS5uZXQvcGFnZV9wZGZfaW1hZ2VzLzE4NTY1MTYzL2ZlODQwNTc2LTIyMWItMTFlZi1hMjRhLTBlZGM1M2MyNWVlNi94X2xhcmdl?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9mbGlwcC1pbWFnZS1yZXRyaWV2YWwuZmxpcHAuY29tL2FwaS9hSFIwY0RvdkwyWXVkMmx6YUdGaWFTNXVaWFF2Y0dGblpWOXdaR1pmYVcxaFoyVnpMekU0TlRZMU1UWXpMMlpsT0RRd05UYzJMVEl5TVdJdE1URmxaaTFoTWpSaExUQmxaR00xTTJNeU5XVmxOaTk0WDJ4aGNtZGw~KiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTcyNTM3NzE1OH19fV19&Signature=eMbd2O~JaqWnWOTFL6TST6AQy1zQTzKofrA0Zkw808JDqjwVlk1CNjLlSQuZk4E7MjU22gWN1au6oP7NIgWGX6e07hwjStaT14M8wWnHZLq-eXAREdef8DGutvEjj9zx6jnE6vAEnUKkejTGL8ETRjenVAIL99oXyN~QU-VZXzE-fSBtnjsWeFu-uFq891OGmpu8sQIPIfwSRxWrObOn0-olCiVEz0oidzkBM2sMfsqXs-TsLt4rWBqB6zaJow9YH5UmkbvYWeLhMMIZD7bb9TQI~ZDylWp14L0tKB2DcHzJoBg~3ts14jlwItYl7sWjR1WG6SiQ91Ax0HQ7ASmM8w__&Key-Pair-Id=KDIF3067XOLU0",
-          "https://flipp-image-retrieval.flipp.com/api/aHR0cDovL2Yud2lzaGFiaS5uZXQvcGFnZV9wZGZfaW1hZ2VzLzE4NTY1MTYzL2ZlODQwNTc2LTIyMWItMTFlZi1hMjRhLTBlZGM1M2MyNWVlNi94X2xhcmdl?Policy=eyJTdGF0ZW1lbnQiOlt7IlJlc291cmNlIjoiaHR0cHM6Ly9mbGlwcC1pbWFnZS1yZXRyaWV2YWwuZmxpcHAuY29tL2FwaS9hSFIwY0RvdkwyWXVkMmx6YUdGaWFTNXVaWFF2Y0dGblpWOXdaR1pmYVcxaFoyVnpMekU0TlRZMU1UWXpMMlpsT0RRd05UYzJMVEl5TVdJdE1URmxaaTFoTWpSaExUQmxaR00xTTJNeU5XVmxOaTk0WDJ4aGNtZGw~KiIsIkNvbmRpdGlvbiI6eyJEYXRlTGVzc1RoYW4iOnsiQVdTOkVwb2NoVGltZSI6MTcyNTM3NzE1OH19fV19&Signature=eMbd2O~JaqWnWOTFL6TST6AQy1zQTzKofrA0Zkw808JDqjwVlk1CNjLlSQuZk4E7MjU22gWN1au6oP7NIgWGX6e07hwjStaT14M8wWnHZLq-eXAREdef8DGutvEjj9zx6jnE6vAEnUKkejTGL8ETRjenVAIL99oXyN~QU-VZXzE-fSBtnjsWeFu-uFq891OGmpu8sQIPIfwSRxWrObOn0-olCiVEz0oidzkBM2sMfsqXs-TsLt4rWBqB6zaJow9YH5UmkbvYWeLhMMIZD7bb9TQI~ZDylWp14L0tKB2DcHzJoBg~3ts14jlwItYl7sWjR1WG6SiQ91Ax0HQ7ASmM8w__&Key-Pair-Id=KDIF3067XOLU0"
-        ],
-        v1Price: "Price",
-        v2Price: "Price",
-        v1PostPrice: "Post price v1",
-        v2PostPrice: "Post price v2",
-        validity: "Valid from a - b",
-        name: "Name",
-        v1SaleStory: "Sale story v1",
-        v2SaleStory: "Sale story v2",
-        description: "Description",
-        sku: "SKU",
-        disclaimer: "Disclaimer"))
+    viewModel: OfferDetailsViewModel(
+      imageURLStrings: [],
+      name: "Sample Offer",
+      priceText: "$4.99",
+      prePriceText: "Now",
+      postPriceText: "each",
+      saleStory: "SAVE BIG",
+      validity: "Valid: Aug 1 - Aug 31",
+      description: "A tasty sample offer.",
+      disclaimer: "While supplies last."))
 }
 
 class OfferDetailsViewModel: ObservableObject {
@@ -126,191 +107,75 @@ class OfferDetailsViewModel: ObservableObject {
   }()
 
   let imageURLStrings: [String]
-  let v1Price: String?
-  let v1PostPrice: String?
-  let v2Price: String?
-  let v2PostPrice: String?
-  let validity: String
   let name: String?
-  let v1SaleStory: String?
-  let v2SaleStory: String?
+  let priceText: String
+  let prePriceText: String?
+  let postPriceText: String?
+  let saleStory: String?
+  let validity: String
   let description: String?
-  let sku: String
   let disclaimer: String?
 
-  init(imageURLStrings: [String],
-       v1Price: String?,
-       v2Price: String?,
-       v1PostPrice: String?,
-       v2PostPrice: String?,
-       validity: String,
-       name: String?,
-       v1SaleStory: String?,
-       v2SaleStory: String?,
-       description: String?,
-       sku: String,
-       disclaimer: String?) {
+  init(
+    imageURLStrings: [String],
+    name: String?,
+    priceText: String,
+    prePriceText: String?,
+    postPriceText: String?,
+    saleStory: String?,
+    validity: String,
+    description: String?,
+    disclaimer: String?
+  ) {
     self.imageURLStrings = imageURLStrings
-    self.v1Price = v1Price
-    self.v2Price = v2Price
-    self.v1PostPrice = v1PostPrice
-    self.v2PostPrice = v2PostPrice
-    self.validity = validity
     self.name = name
-    self.v1SaleStory = v1SaleStory?.isEmpty == false ? v1SaleStory : nil
-    self.v2SaleStory = v2SaleStory?.isEmpty == false ? v2SaleStory : nil
-    self.description = description?.isEmpty == false ? description : nil
-    self.sku = sku
+    self.priceText = priceText
+    self.prePriceText = prePriceText
+    self.postPriceText = postPriceText
+    self.saleStory = saleStory
+    self.validity = validity
+    self.description = description
     self.disclaimer = disclaimer
   }
 
   convenience init(from offer: Offer) {
-    var validity = "Valid: "
+    self.init(
+      imageURLStrings: offer.imageURLs,
+      name: offer.name,
+      priceText: Self.priceText(for: offer.pricing),
+      prePriceText: offer.prePriceText,
+      postPriceText: offer.postPriceText,
+      saleStory: offer.saleStory,
+      validity: Self.validity(from: offer.validFrom, to: offer.validTo),
+      description: offer.description,
+      disclaimer: offer.disclaimer)
+  }
 
-    if let validFrom = offer.dates?.validFrom {
-      validity.append(Self.dateFormatter.string(from: validFrom))
+  /// Composes a display price from the available pricing fields, preferring an
+  /// explicit sale/regular price, then falling back to a percentage/amount off.
+  private static func priceText(for pricing: OfferPricing?) -> String {
+    guard let pricing else { return "" }
+    if let salePrice = pricing.salePrice {
+      return String(format: "$%.2f", salePrice)
+    } else if let price = pricing.price {
+      return String(format: "$%.2f", price)
+    } else if let percentOff = pricing.percentOff {
+      return String(format: "%.0f%% OFF", percentOff)
+    } else if let amountOff = pricing.amountOff {
+      return String(format: "$%.2f OFF", amountOff)
+    }
+    return ""
+  }
+
+  private static func validity(from: Date?, to: Date?) -> String {
+    var validity = "Valid: "
+    if let from {
+      validity.append(dateFormatter.string(from: from))
       validity.append(" - ")
     }
-
-    if let validTo = offer.dates?.validTo {
-      validity.append(Self.dateFormatter.string(from: validTo))
+    if let to {
+      validity.append(dateFormatter.string(from: to))
     }
-
-    var v1PriceString = ""
-
-    if let prePrice = offer.offerDetails?.prePriceText, !prePrice.isEmpty {
-      v1PriceString.append(prePrice)
-      v1PriceString.append(" ")
-    }
-
-    if let price = offer.pricing?.salePrice {
-      v1PriceString.append("$\(price)")
-    } else if let price = offer.pricing?.price {
-      v1PriceString.append("$\(price)")
-    }
-
-    var imageURLStrings = [String]()
-
-    if let imageURL = offer.details?.imageURL {
-      imageURLStrings.append(imageURL)
-    }
-
-    if let additionalImages = offer.details?.additionalMedia?.compactMap({ $0.url }) {
-      imageURLStrings.append(contentsOf: additionalImages)
-    }
-
-    let pricingTexts = Self.v1PriceTextMappingFromV2English(offer: offer)
-
-    var v2PriceString = ""
-
-    if !pricingTexts.prePrice.isEmpty {
-      v2PriceString.append(pricingTexts.prePrice)
-      v2PriceString.append(" ")
-    }
-
-    v2PriceString.append("\(pricingTexts.price)")
-
-    self.init(
-      imageURLStrings: imageURLStrings,
-      v1Price: v1PriceString.isEmpty == false ? v1PriceString : nil,
-      v2Price: v2PriceString,
-      v1PostPrice: offer.offerDetails?.postPriceText,
-      v2PostPrice: pricingTexts.postPrice,
-      validity: validity,
-      name: offer.details?.name,
-      v1SaleStory: offer.offerDetails?.saleStory,
-      v2SaleStory: Self.v1SalesStoryMappingFromV2English(offer: offer),
-      description: offer.details?.description,
-      sku: "SKU: \(offer.details?.additionalInfo["sku"] ?? "")",
-      disclaimer: offer.offerDetails?.disclaimer)
-  }
-
-
-  // Compose V1 fields from V2 mappings.
-  static func v1SalesStoryMappingFromV2English(offer: Offer) -> String {
-    let labels = offer.pricing?.labels
-    var saleStory = offer.offerDetails?.saleStory ?? ""
-    let pricing = offer.pricing
-    let prePriceText = offer.offerDetails?.prePriceText ?? ""
-
-    // "Save" Labels
-    if let labels = labels, labels.contains("show-save") {
-      saleStory = "SAVE \(saleStory)"
-    }
-
-    // Qualifying Quantity
-    if offer.pricing?.offerType == .buyXgetY,
-       let percentOff = pricing?.percentOff,
-       let qualifyingQuantity = pricing?.qualifyingQuantity,
-       let rewardQuantity = pricing?.rewardQuantity {
-      if !saleStory.isEmpty {
-        saleStory += " "
-      }
-      saleStory += "BUY \(qualifyingQuantity) GET \(rewardQuantity) \(percentOff)% OFF"
-    } else if let qualifyingQuantity = pricing?.qualifyingQuantity,
-              !(prePriceText.range(of: "Buy \\d+ Or More", options: .regularExpression) != nil) {
-      if !saleStory.isEmpty {
-        saleStory += " "
-      }
-      saleStory += "WHEN YOU BUY \(qualifyingQuantity)"
-    }
-
-    // Loyalty
-    if let loyaltyPoints = pricing?.loyaltyPoints {
-      if !saleStory.isEmpty {
-        saleStory += ", "
-      }
-      saleStory += "PC Optimum \(loyaltyPoints) pts"
-
-      if let loyaltyPointsStory = offer.details?.additionalInfo["loyaltyPointsStory"] as? String,
-         !loyaltyPointsStory.isEmpty {
-        saleStory += " \(loyaltyPointsStory)"
-      }
-      if let loyaltyValue = offer.details?.additionalInfo["loyaltyPointsValue"] {
-        saleStory += ", $\(loyaltyValue) Value"
-      }
-    }
-
-    return saleStory
-  }
-
-  // Compose v1 sales story from v2 mappings.
-  static func v1PriceTextMappingFromV2English(offer: Offer) -> (prePrice: String, price: String, postPrice: String, wasPrice: String) {
-    let offerDetails = offer.offerDetails
-    let pricing = offer.pricing
-
-    let prePriceText = offerDetails?.prePriceText ?? ""
-    var priceText = ""
-    var wasPriceText = ""
-    let postPriceText = offerDetails?.postPriceText ?? ""
-
-    // Get the price text
-    let priceRange = pricing?.salePriceRange ?? pricing?.priceRange
-    let price = pricing?.salePrice ?? pricing?.price
-    if let range = priceRange {
-      priceText = "$\(String(format: "%.2f", range.from)) - $\(String(format: "%.2f", range.to))"
-    } else if let price = price {
-      priceText = "$\(String(format: "%.2f", price))"
-    } else if pricing?.offerType == .percentOff, let percentOff = pricing?.percentOff {
-      priceText = "\(percentOff)% OFF"
-    } else if pricing?.offerType == .amountOff, let amountOff = pricing?.amountOff {
-      priceText = "$\(amountOff) OFF"
-    }
-
-    let wasPriceRange = pricing?.salePriceRange != nil ? pricing?.priceRange : nil
-    let wasPrice = pricing?.salePrice != nil ? pricing?.price : nil
-    if let range = wasPriceRange {
-      wasPriceText = "$\(String(format: "%.2f", range.from)) - $\(String(format: "%.2f", range.to))"
-    } else if let price = wasPrice {
-      wasPriceText = "$\(String(format: "%.2f", price))"
-    }
-
-
-    return (
-      prePriceText.trimmingCharacters(in: .whitespacesAndNewlines),
-      priceText.trimmingCharacters(in: .whitespacesAndNewlines),
-      postPriceText.trimmingCharacters(in: .whitespacesAndNewlines),
-      wasPriceText.trimmingCharacters(in: .whitespacesAndNewlines)
-    )
+    return validity
   }
 }

--- a/dvm-sample/PublicationViewController.swift
+++ b/dvm-sample/PublicationViewController.swift
@@ -34,8 +34,7 @@ class PublicationViewController: UIViewController {
 
     if let rendererView = try? DVMSDK.createRenderingView(
       publicationId: publicationID,
-      merchantId: merchantId,
-      storeCode: storeCode,
+      publicationInfo: .byMerchant(merchantId: merchantId, storeCode: storeCode),
       renderMode: renderingMode,
       language: Locale.preferredLanguageCode() ?? "en",
       shouldPersistWebsiteDataToDisk: false
@@ -73,7 +72,7 @@ extension PublicationViewController: DVMRendererDelegate {
     // publication finished loading
   }
   
-  func didTap(result: Result<dvm_sdk.Offer, dvm_sdk.DVMSDKError>) {
+  func didTap(result: Result<Offer, DVMSDKError>) {
     switch result {
     case .success(let offer):
       self.pushDetailsController(for: offer)

--- a/dvm-sample/PublicationViewController.swift
+++ b/dvm-sample/PublicationViewController.swift
@@ -13,50 +13,108 @@ class PublicationViewController: UIViewController {
   var publicationID: String?
   var merchantId: String?
   var storeCode: String?
+  var renderOptions = RenderOptions(disableZoom: false, linkedOfferId: nil, postalCode: nil, countryCode: nil)
   lazy var spinner = UIActivityIndicatorView()
 
   private var rendererView: DVMRendererView?
+
+  /// A native view pinned to the bottom that overlays the publication. Space for it is
+  /// reserved via `DVMRendererView.bottomContentInset` so publication content can scroll
+  /// clear of it — showcasing native content layered over the rendered publication.
+  private let footerView = UIView()
+  private let statusLabel = UILabel()
+  private static let footerHeight: CGFloat = 44
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     title = "Publication"
+    view.backgroundColor = .appBackground
     navigationItem.rightBarButtonItem = UIBarButtonItem(customView: spinner)
     spinner.startAnimating()
 
-    guard let publicationID,
-          let renderingMode,
-          let merchantId,
-          let storeCode else {
+    guard let publicationID, let renderingMode else {
       spinner.stopAnimating()
+      return
+    }
+
+    guard let publicationInfo = makePublicationInfo() else {
+      spinner.stopAnimating()
+      setStatus("Missing merchant/store or postal/country info")
       return
     }
 
     if let rendererView = try? DVMSDK.createRenderingView(
       publicationId: publicationID,
-      publicationInfo: .byMerchant(merchantId: merchantId, storeCode: storeCode),
+      publicationInfo: publicationInfo,
       renderMode: renderingMode,
       language: Locale.preferredLanguageCode() ?? "en",
-      shouldPersistWebsiteDataToDisk: false
+      shouldPersistWebsiteDataToDisk: false,
+      disableZoom: renderOptions.disableZoom,
+      linkedOfferId: renderOptions.linkedOfferId
     ) {
       rendererView.rendererDelegate = self
       rendererView.translatesAutoresizingMaskIntoConstraints = false
       view.addSubview(rendererView)
       self.rendererView = rendererView
+
+      setupFooter()
       setupConstraints()
+
+      // Reserve scroll space for the native footer overlaying the publication.
+      rendererView.bottomContentInset = Self.footerHeight
     }
-    
+
     spinner.stopAnimating()
   }
 
-  private func setupConstraints() {
-    rendererView?.topAnchor.constraint(equalTo: view.topAnchor).isActive = true
-    rendererView?.leadingAnchor.constraint(equalTo: view.leadingAnchor).isActive = true
-    rendererView?.trailingAnchor.constraint(equalTo: view.trailingAnchor).isActive = true
-    rendererView?.bottomAnchor.constraint(equalTo: view.bottomAnchor).isActive = true
+  /// Prefer location-based rendering when a postal + country code were provided,
+  /// otherwise fall back to merchant/store.
+  private func makePublicationInfo() -> PublicationInfo? {
+    if let postalCode = renderOptions.postalCode, let countryCode = renderOptions.countryCode {
+      return .byLocation(postalCode: postalCode, countryCode: countryCode)
+    }
+    if let merchantId, let storeCode {
+      return .byMerchant(merchantId: merchantId, storeCode: storeCode)
+    }
+    return nil
   }
 
-  override func viewDidAppear(_ animated: Bool) {
+  private func setupFooter() {
+    footerView.translatesAutoresizingMaskIntoConstraints = false
+    footerView.backgroundColor = .primary3
+    statusLabel.translatesAutoresizingMaskIntoConstraints = false
+    statusLabel.textColor = .default0
+    statusLabel.font = .systemFont(ofSize: 13)
+    statusLabel.numberOfLines = 1
+    statusLabel.adjustsFontSizeToFitWidth = true
+    statusLabel.text = "Ready"
+    footerView.addSubview(statusLabel)
+    view.addSubview(footerView)
+  }
+
+  private func setupConstraints() {
+    guard let rendererView else { return }
+    NSLayoutConstraint.activate([
+      rendererView.topAnchor.constraint(equalTo: view.topAnchor),
+      rendererView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      rendererView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      rendererView.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+
+      footerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+      footerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+      footerView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
+      footerView.heightAnchor.constraint(equalToConstant: Self.footerHeight),
+
+      statusLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor, constant: 12),
+      statusLabel.trailingAnchor.constraint(equalTo: footerView.trailingAnchor, constant: -12),
+      statusLabel.centerYAnchor.constraint(equalTo: footerView.centerYAnchor),
+    ])
+  }
+
+  private func setStatus(_ text: String) {
+    statusLabel.text = text
+    Self.logger.debug("\(text, privacy: .public)")
   }
 
   func pushDetailsController(for offer: Offer) {
@@ -68,24 +126,89 @@ class PublicationViewController: UIViewController {
 }
 
 extension PublicationViewController: DVMRendererDelegate {
-  func didFinishLoad(legacyMap: [String : String]) {
-    // publication finished loading
-  }
-  
-  func didTap(result: Result<Offer, DVMSDKError>) {
-    switch result {
-    case .success(let offer):
-      self.pushDetailsController(for: offer)
-    case .failure(let error):
-      Self.logger.error("Error tapping on offer: \(error.localizedDescription)")
-    }
-  }
-
-  func didFinishLoad() {
-    Self.logger.debug("Did finish load")
+  func didFinishLoad(legacyMap: [String: String]) {
+    setStatus("Loaded")
   }
 
   func didFailToLoad(error: Error) {
-    Self.logger.error("Failed to load publication: \(error.localizedDescription)")
+    setStatus("Failed to load: \(error.localizedDescription)")
+  }
+
+  // MARK: Offers
+
+  func didTap(result: Result<Offer, DVMSDKError>) {
+    switch result {
+    case .success(let offer):
+      pushDetailsController(for: offer)
+    case .failure(let error):
+      setStatus("Tap error: \(error.localizedDescription)")
+    }
+  }
+
+  func didLongTap(result: Result<Offer?, DVMSDKError>) {
+    if case .success(let offer?) = result {
+      setStatus("Long tapped: \(offer.name ?? offer.id)")
+      pushDetailsController(for: offer)
+    }
+  }
+
+  func publicationImpression(ids: [String]) {
+    setStatus("Offer impressions: \(ids.count)")
+  }
+
+  // MARK: Promotions
+
+  func didTapPromotion(result: Result<Promotion, DVMSDKError>) {
+    switch result {
+    case .success(let promotion):
+      setStatus("Tapped promotion: \(promotion.name ?? promotion.id)")
+    case .failure(let error):
+      setStatus("Promotion tap error: \(error.localizedDescription)")
+    }
+  }
+
+  func publicationScrollToPromotionResponse(_ promotion: Promotion) {
+    setStatus("Scrolled to promotion: \(promotion.name ?? promotion.id)")
+  }
+
+  func publicationPromotionImpression(ids: [String]) {
+    setStatus("Promotion impressions: \(ids.count)")
+  }
+
+  // MARK: Through-the-merchant links
+
+  func didTapTTM(url: URL) {
+    setStatus("TTM tapped: \(url.absoluteString)")
+    UIApplication.shared.open(url)
+  }
+
+  // MARK: Linked-offer / hydration strategy results
+
+  func didReceiveStrategyResults(_ results: [StrategyResult]) {
+    if let failure = results.first(where: { $0.errorMessage != nil }) {
+      let message = failure.errorMessage ?? "unknown error"
+      setStatus("Strategy error: \(message)")
+      let alert = UIAlertController(title: "Linked offer not loaded", message: message, preferredStyle: .alert)
+      alert.addAction(UIAlertAction(title: "OK", style: .default))
+      present(alert, animated: true)
+    } else {
+      setStatus("Strategy results: \(results.count) ok")
+    }
+  }
+
+  // MARK: Scroll telemetry
+
+  func publicationDidScroll(contentOffset: CGPoint, contentSize: CGSize, viewportHeight: CGFloat) {
+    let scrollable = max(contentSize.height - viewportHeight, 1)
+    let progress = min(max(contentOffset.y / scrollable, 0), 1)
+    setStatus(String(format: "Scroll: %.0f%%", progress * 100))
+  }
+
+  func publicationDidEndDragging(willDecelerate: Bool) {
+    Self.logger.debug("Did end dragging, willDecelerate: \(willDecelerate)")
+  }
+
+  func publicationDidEndDecelerating() {
+    Self.logger.debug("Did end decelerating")
   }
 }

--- a/dvm-sample/Publications/PublicationsViewController.swift
+++ b/dvm-sample/Publications/PublicationsViewController.swift
@@ -18,6 +18,7 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
   var publications: [Publication] = []
   var merchantID: String?
   var storeCode: String?
+  var renderOptions = RenderOptions(disableZoom: false, linkedOfferId: nil, postalCode: nil, countryCode: nil)
 
   let tableView: UITableView = {
     let tableView = UITableView()
@@ -141,6 +142,7 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
     publicationVC.merchantId = self.merchantID
     publicationVC.storeCode = self.storeCode
     publicationVC.renderingMode = mode
+    publicationVC.renderOptions = self.renderOptions
     navigationController?.pushViewController(publicationVC, animated: true)
   }
 }

--- a/dvm-sample/Publications/PublicationsViewController.swift
+++ b/dvm-sample/Publications/PublicationsViewController.swift
@@ -15,7 +15,7 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
     return dateFormatter
   }()
 
-  var publications: PublicationsList?
+  var publications: [Publication] = []
   var merchantID: String?
   var storeCode: String?
 
@@ -84,22 +84,19 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
   // MARK: - UITableViewDataSource
 
   func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
-    guard publications != nil else {
+    guard !publications.isEmpty else {
       return nil
     }
     let view = tableView.dequeueReusableHeaderFooterView(withIdentifier: "sectionHeader") as? SectionHeader
-    view?.label.text = "\(publications?.publications.count ?? 0) publication(s)"
+    view?.label.text = "\(publications.count) publication(s)"
     return view
   }
 
   func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-    return publications?.publications.count ?? 0
+    return publications.count
   }
 
   func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-    guard let publications = publications?.publications else {
-      return UITableViewCell()
-    }
     guard let cell = tableView.dequeueReusableCell(withIdentifier: PublicationCell.reuseIdentifier, for: indexPath) as? PublicationCell else {
       fatalError("Bad cell")
     }
@@ -107,7 +104,7 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
     cell.delegate = self
 
     let publication = publications[indexPath.row]
-    if let urlString = publication.details?.imageURL,
+    if let urlString = publication.imageURL,
        let url = URL(string: urlString) {
       cell.cellImageView.loadImage(from: url)
       cell.cellImageView.isHidden = false
@@ -115,14 +112,14 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
       cell.cellImageView.image = nil
       cell.cellImageView.isHidden = true
     }
-    cell.titleLabel.text = publication.details?.name ?? ""
-    if let description = publication.details?.description {
+    cell.titleLabel.text = publication.name ?? ""
+    if let description = publication.description {
       cell.subtitleLabel.text = description
     } else {
       cell.subtitleLabel.text = ""
     }
-    if let validFrom = publication.dates?.validFrom,
-       let validTo = publication.dates?.validTo {
+    if let validFrom = publication.validFrom,
+       let validTo = publication.validTo {
       cell.validLabel.text = "Valid: \(dateFormatter.string(from: validFrom)) - \(dateFormatter.string(from: validTo))"
     } else {
       cell.validLabel.text = ""
@@ -140,7 +137,7 @@ class PublicationsViewController: UIViewController, UITableViewDataSource, UITab
 
   private func showPublication(_ publication: Publication, mode: RenderMode) {
     let publicationVC = PublicationViewController()
-    publicationVC.publicationID = publication.globalID
+    publicationVC.publicationID = publication.id
     publicationVC.merchantId = self.merchantID
     publicationVC.storeCode = self.storeCode
     publicationVC.renderingMode = mode
@@ -154,8 +151,7 @@ extension PublicationsViewController: PublicationCellDelegate {
       return
     }
 
-    guard let publications = publications?.publications,
-          indexPath.row < publications.count else {
+    guard indexPath.row < publications.count else {
       return
     }
 
@@ -167,8 +163,7 @@ extension PublicationsViewController: PublicationCellDelegate {
       return
     }
 
-    guard let publications = publications?.publications,
-          indexPath.row < publications.count else {
+    guard indexPath.row < publications.count else {
       return
     }
 


### PR DESCRIPTION
Updates the sample app to DVM SDK **3.5.1** (`dvm-ios-binaries` 2.1.6 → 3.5.1) and extends it to demonstrate the features added since 2.1.6.

## Migration to 3.5.1
- **Dependency:** `dvm-ios-binaries` exact `3.5.1` (`project.pbxproj` + `Package.resolved`).
- **Self-contained SDK types:** `fetchPublicationsList` → `[Publication]`; `DVMRendererDelegate` offer callbacks use `Offer`/`Promotion`. Field access updated to the new value types.
- **`createRenderingView`:** now takes `publicationInfo` instead of separate `merchantId`/`storeCode`.
- **OfferDetailsView:** simplified to map directly from the new `Offer` wrapper.

## New features now showcased
- **Location-based rendering** — optional Postal/Country fields drive `PublicationInfo.byLocation`; otherwise `.byMerchant`.
- **`disableZoom`** — toggle on the initial screen.
- **`linkedOfferId`** — optional field; paired with **`didReceiveStrategyResults`**, which surfaces a linked-offer error via an alert.
- **Promotions** — `didTapPromotion`, `publicationScrollToPromotionResponse`, `publicationPromotionImpression`.
- **`didTapTTM(url:)`** — opens the through-the-merchant URL.
- **`bottomContentInset` + `scrollView`** — reserves space for a native footer overlay that also shows the latest renderer event.
- **Scroll telemetry** — `publicationDidScroll(contentOffset:contentSize:viewportHeight:)` (shows scroll %), `publicationDidEndDragging`, `publicationDidEndDecelerating`; plus `didLongTap`.

## Verification
- `xcodebuild` build succeeds for iOS Simulator against `dvm-ios-binaries@3.5.1`.
- App launches and renders both the initial screen (with the new options) in the simulator (verified with a temporary dummy key; `SDKKey` remains empty in the repo — set a real Flipp key to load publications).

🤖 Generated with [Claude Code](https://claude.com/claude-code)